### PR TITLE
add headless flag for CLI execution

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -28,7 +28,14 @@
 #include <httplib.h>
 
 int main(int argc, char **argv) {
-    if (argc > 1) {
+    bool headless = false;
+    for (int i = 1; i < argc; ++i) {
+        if (QString(argv[i]) == "--headless") {
+            headless = true;
+            break;
+        }
+    }
+    if (argc > 1 && !headless) {
         return shijimaRunCli(argc, argv);
     }
     Platform::initialize(argc, argv);
@@ -46,7 +53,9 @@ int main(int argc, char **argv) {
         if (pingResult != nullptr) {
             throw std::runtime_error("Shijima-Qt is already running!");
         }
-        ShijimaManager::defaultManager()->show();
+        if (!headless) {
+            ShijimaManager::defaultManager()->show();
+        }
     }
     catch (std::exception &ex) {
         QMessageBox *msg = new QMessageBox {};


### PR DESCRIPTION
Hello, I would like be able to run Shijima-Qt in headless mode without the need to display the manager window. This is my personal proposal how we could achieve it. It might as well solve the issue [#48](https://github.com/pixelomer/Shijima-Qt/issues/48), which in particular requests just this behavior. What did I change?

- I added a headless flag in **main.cc**.
- When headless flag is passed, the manager window is not shown and other CLI arguments are not evaluated, thus the application process is just being launched without user interface.
- User can run the CLI commands, .e.g. to spawn mascots, since the application process is already running in the background.