### PR TITLE
fix: use https for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "libshijima"]
 	path = libshijima
-	url = git@github.com:pixelomer/libshijima
+	url = https://github.com/pixelomer/libshijima
 [submodule "libshimejifinder"]
 	path = libshimejifinder
-	url = git@github.com:pixelomer/libshimejifinder
+	url = https://github.com/pixelomer/libshimejifinder
 [submodule "cpp-httplib"]
 	path = cpp-httplib
 	url = https://github.com/yhirose/cpp-httplib


### PR DESCRIPTION
Using https instead of ssh for submodules, using ssh when the submodules aren't private repos is kinda useless and makes it a bit of a hassle when packaging the app.