### PR TITLE
Add StartupWMClass to ShijimaQt desktop file

### DIFF
--- a/com.pixelomer.ShijimaQt.desktop
+++ b/com.pixelomer.ShijimaQt.desktop
@@ -4,6 +4,7 @@ Version=1.0
 Name=Shijima-Qt
 Comment=Shimeji desktop pet runner
 Exec=shijima-qt
+StartupWMClass=Shijima-Qt
 Icon=com.pixelomer.ShijimaQt
 Terminal=false
 Categories=Game


### PR DESCRIPTION
Not a big change. Saw that the AppImage didn't display its icon on my taskbar even after using Gear Lever. Figured out it was because it was missing the StartupWMClass and now it works :)